### PR TITLE
Set minimum version of swift tools to 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.5
 
 import PackageDescription
 


### PR DESCRIPTION
Using swift v5.5 allows for broadest adoption of Xcode. It is also the first version that supports iOS15.

<img width="1279" alt="Screenshot 2024-09-11 at 1 06 13 PM" src="https://github.com/user-attachments/assets/ce9db9a1-9699-45eb-86d3-57dfb208563c">

https://xcodereleases.com/?scope=release
