### PR TITLE
Fix Capacitor Swift PM dependency version to resolve startup failures

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ionic-team/capacitor-swift-pm",
         "state": {
           "branch": null,
-          "revision": "272e5dcd26260c6f3798b024c9cb3ffa52850ec7",
-          "version": "6.1.2"
+          "revision": "3fe94bbbe43e63ada75aa6788fc10e3764622a97",
+          "version": "6.2.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm", from: "6.1.2"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm", from: "6.2.1"),
     ],
     targets: [
         .binaryTarget(name: "FeltEmbeddedCare", path: "Binaries/FeltEmbeddedCare.xcframework.zip"),


### PR DESCRIPTION
Updated capacitor-swift-pm from 6.1.2 to 6.2.1 to fix application startup issues that were preventing users from running the application successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)